### PR TITLE
Fix Bitfinex BTC-USD price feed

### DIFF
--- a/libexec/setzer/setzer-price-btcusd
+++ b/libexec/setzer/setzer-price-btcusd
@@ -17,12 +17,7 @@ case $1 in
     usdt_usd=$(setzer x-price cmc usdtusd)
     setzer --format "$(bc -l <<<"$btc_usdt * $usdt_usd")"
   };;
-  bitfinex) {
-    btc_usdt=$(setzer x-price "$1" btcusd)
-    usdt_usd=$(setzer x-price cmc usdtusd)
-    setzer --format "$(bc -l <<<"$btc_usdt * $usdt_usd")"
-  };;
-  bitstamp|coinbase|gemini) {
+  bitfinex|bitstamp|coinbase|gemini) {
     setzer x-price "$1" $pair
   };;
   kraken) {


### PR DESCRIPTION
Currently, the BTC-USD price is pulled from Bitfinex and then multiplied by the USDT-USD price. Instead, the BTC-USD price should be returned directly.

The ticker symbol param for BTC-USD is [`tBTCUSD`](https://api.bitfinex.com/v2/ticker/tBTCUSD) whereas the one for BTC-USDT is [`tBTCUST`](https://api.bitfinex.com/v2/ticker/tBTCUST).

![image](https://user-images.githubusercontent.com/3301218/79333056-bd287a80-7ed2-11ea-968d-53c4d018f851.png)

These prices can be compared to the ones on the bitfinex.com home page:

![image](https://user-images.githubusercontent.com/3301218/79333133-d9c4b280-7ed2-11ea-8ec1-3bf2a9b49046.png)
