### PR TITLE
wstETH/USD support

### DIFF
--- a/libexec/setzer/setzer---eth-call
+++ b/libexec/setzer/setzer---eth-call
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# all in hex format
+contract_addr=${1#0x}
+method_id=${2#0x}
+args=${3#0x} # ABI-encoded
+
+: ${ETH_RPC_URL:=${ETH_RPC_HOST:-http://127.0.0.1}:${ETH_RPC_PORT:-8545}}
+
+hex_0x=$(curl \
+  -sS \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"'"0x$contract_addr"'","data":"'"0x$method_id$args"'"},"latest"],"id":1}' \
+  "$ETH_RPC_URL" | jshon -e result -u)
+
+if ! [[ $hex_0x == 0x* ]]; then
+  echo >&2 "Error: invalid JSON-RPC result received: $hex_0x"
+  exit 1
+fi
+
+# output in an uppercase hex format, e.g. AABB
+hex=${hex_0x#0x}
+printf '%s' "${hex^^}"

--- a/libexec/setzer/setzer-price-wstethusd
+++ b/libexec/setzer/setzer-price-wstethusd
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+pair=wstethusd
+sources=(
+  curve
+)
+
+case $1 in
+  curve) {
+    wsteth_eth=$(setzer x-price "$1" wsteth:eth)
+    eth_usd=$(setzer price ethusd)
+    setzer --format "$(bc -l <<<"$wsteth_eth * $eth_usd")"
+  };;
+  *) {
+    export SETZER_MIN_MEDIAN=1
+    setzer --price-commands "-$1-" $pair "${sources[@]}"
+  };;
+esac

--- a/libexec/setzer/setzer-x-price
+++ b/libexec/setzer/setzer-x-price
@@ -68,6 +68,44 @@ case $src in
     json=$(curl -sS "https://min-api.cryptocompare.com/data/price?fsym=${base^^}&tsyms=${quote^^}")
     setzer --format "$(jshon <<<"$json" -e USD -u)"
   };;
+  curve) {
+    ten_to_18=$(printf '%064X' 1000000000000000000) # 10^18 left-padded to 32 bytes
+    case "${pair^^}" in
+      WSTETHETH) {
+        crv_contract_addr=DC24316b9AE028F1497c275EB9192a3Ea0f67022 # stETH/ETH pool
+        crv_src_token=$(printf '%064X' 1) # stETH index
+        crv_dst_token=$(printf '%064X' 0) # ETH index
+        crv_src_amount=$ten_to_18
+      };;
+      *) {
+        echo >&2 "Error: pair not supported for Curve exchange: $pair"
+      };;
+    esac
+    # keccak256("get_dy(int128,int128,uint256)")
+    get_dy_method_id=5e0d443f
+    crv_dst_amount=$(setzer \
+      --eth-call \
+      "$crv_contract_addr" \
+      "$get_dy_method_id" \
+      "$crv_src_token$crv_dst_token$crv_src_amount"
+    )
+    case "${pair^^}" in
+      WSTETHETH) {
+        # wstETH is a non-rebasing wrapper that exposes the underlying stETH shares
+        wsteth_contract_addr=7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0
+        # keccak256("stEthPerToken()")
+        steth_per_token_method_id=035faf82
+        # how many stETH wei one would receive by unwarpping 10^18 wstETH wei
+        steth_per_wsteth=$(setzer --eth-call "$wsteth_contract_addr" "$steth_per_token_method_id")
+        # wstethEthPrice = stethPerWsteth * stethEthPrice
+        price=$(bc -l <<<"ibase=16; (${steth_per_wsteth^^} * ${crv_dst_amount^^}) / (${crv_src_amount^^} * ${ten_to_18^^})")
+      };;
+      *) {
+        price=$(bc -l <<<"ibase=16; ${crv_dst_amount^^} / ${crv_src_amount^^}")
+      };;
+    esac
+    setzer --format "$price"
+  };;
   ddex) {
     json=$(curl -sS "https://api.ddex.io/v4/markets/${base^^}-${quote^^}")
     setzer --format "$(jshon <<<"$json" -e data -e market -e lastPrice -u)"


### PR DESCRIPTION
#### Summary

* Add support for querying Curve spot prices using the `eth_call` JSON-RPC request.
* Add Curve price source for wstETH/ETH pair.
* Add support for querying wstETH/USD price.

#### Why JSON-RPC?

The decision behind querying Curve prices via JSON-RPC instead of using The Graph protocol relies on the two considerations:

1. There are no widely used Curve subgraphs that support querying spot prices.
2. Using JSON-RPC allows each feed operator to use their own endpoint whilst querying a subgraph makes The Graph API endpoint a single point of failure.

The previous version of Setzer depended on [Seth](https://github.com/dapphub/dapptools/tree/master/src/seth) for accessing Ethereum client API. Instead of re-introducing this dependency, this PR implements a minimalistic `setzer --eth-call` utility. Both this utility and the general support of Curve as a price source can be re-used for other pairs.

The JSON-RPC endpoint can be configured using the `ETH_RPC_URL` or `ETH_RPC_HOST`/`ETH_RPC_PORT` environment variables (the same as in Seth).

#### The number of price sources

wstETH is a non-rebasing wrapper that exposes the underlying stETH shares. Currently, the vast majority of liquidity for stETH/ETH pair (~$1.9B at the time of writing) is concentrated in the Curve pool so we had to set `SETZER_MIN_MEDIAN` to 1. We're planning to add more liquidity sources soon and update the code accordingly.